### PR TITLE
Make the prompt rule and its check agree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ record project status, plans, or "we decided X" in `docs/`; that belongs in `.ag
   local requantization inputs; the Video and Audio VAEs remain dense runtime inputs.
 - The default active-memory budget is 70 GiB. Swap activity is a hard failure.
   Do not weaken, bypass, or suppress the memory guard to make a run pass.
-- Do not commit real generation prompts or generated examples, including in tests,
-  docs, fixtures, issue templates, or release notes.
+- Never commit local generation prompts, cases, or generated media, including in
+  tests, docs, fixtures, issue templates, and release notes.
 
 Run `python dev/check_public_tree.py` before exposing repository contents. The
 pre-commit hook applies the same policy to staged files.

--- a/dev/check_public_tree.py
+++ b/dev/check_public_tree.py
@@ -59,19 +59,42 @@ FORBIDDEN_SUFFIXES = {
     ".webp",
 }
 
+# Field names from H3's structured briefs, in their assigned form. The text-only
+# brief carries the first three; a reference brief adds the rest. Each is split
+# across adjacent literals so the joined marker never appears in this file, which
+# is itself scanned. Do not join them.
+#
+# A brief written as free prose, naming no field, still passes. No content check
+# recognises that; the directory, suffix, and filename rules above are what keep
+# working input out.
 PRIVATE_PROMPT_MARKERS = {
     "integrated_multimodal_" "description:",
     "non_diegetic_" "music:",
     "overall_" "soundscape:",
+    "subject_" "definitions:",
+    "retention_" "analysis:",
+    "detailed_" "description:",
 }
 
 TEXT_SUFFIXES = {
     "",
+    ".cfg",
+    ".csv",
+    ".css",
+    ".html",
     ".ini",
+    ".js",
+    ".json",
+    ".jsonl",
     ".md",
     ".py",
+    ".rst",
+    ".sh",
+    ".svg",
     ".toml",
+    ".tsv",
     ".txt",
+    ".xml",
     ".yaml",
     ".yml",
 }


### PR DESCRIPTION
Two commits.

**`AGENTS.md`** — the rule read as a ban on prompt-related content anywhere, which would rule out documenting the prompt interface at all. It now says what it protects: local material from an actual run.

```
- Never commit local generation prompts, cases, or generated media, including in
  tests, docs, fixtures, issue templates, and release notes.
```

**`dev/check_public_tree.py`** — the guard was narrower than the rule. Two gaps:

1. `PRIVATE_PROMPT_MARKERS` held only the text-only brief's three fields, so a reference brief passed on `subject_definitions`, `retention_analysis`, and `detailed_description`.
2. `TEXT_SUFFIXES` omitted JSON, so a brief saved as `.json` was never read.

`summary:` is deliberately excluded — too common to match without failing ordinary documents.

Verified on staged probes: all six markers blocked, `.json`/`.jsonl` now scanned, `summary:` passes, and prose naming a field without assigning to it still passes.

A brief written as free prose naming no field remains undetectable by any content check. That limit is now stated in a comment rather than left implicit.