### PR TITLE
Add Hugging Face publishing for the 8-bit artifacts

### DIFF
--- a/scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md
+++ b/scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md
@@ -1,0 +1,117 @@
+---
+license: other
+license_name: minimax-h3-community-license
+license_link: https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE
+library_name: mlx
+pipeline_tag: text-to-video
+base_model: MiniMaxAI/MiniMax-H3
+tags:
+- mlx
+- apple-silicon
+- minimax
+- text-to-video
+- text-to-audio-video
+- audio-video-generation
+- quantized
+---
+
+# MiniMax-H3-Base — MLX (8-bit)
+
+[![GitHub](https://img.shields.io/badge/GitHub-mlx--h3-181717?logo=github&logoColor=white)](https://github.com/appautomaton/mlx-h3)
+[![App Automaton](https://img.shields.io/badge/App%20Automaton-project-1f6feb)](https://appautomaton.renocrypt.com/mlx-h3/)
+[![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97-appautomaton-yellow)](https://huggingface.co/appautomaton)
+
+MLX affine 8-bit quantization of **H3-Base**, the open stage of
+[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) — text to synchronized video and
+stereo audio, denoised together in one packed sequence. Runs through the
+[`mlx-h3`](https://github.com/appautomaton/mlx-h3) runtime on Apple silicon, with no
+PyTorch at inference time.
+
+## Contents
+
+| Path | Size | What it is |
+| --- | --- | --- |
+| `dit-fl2va/dit_fl2va_a8g32.safetensors` | 34.8 GiB | DiT for text-only and 0–2 keyframe conditioning |
+| `dit-ref2va/dit_ref2va_a8g32.safetensors` | 34.8 GiB | DiT for reference conditioning — up to 9 images, 3 videos, 3 audio clips |
+| `text-encoder/te_qwen3vl_a8g32.safetensors` | 27.7 GiB | Qwen3-VL-32B text encoder and vision tower |
+
+The two DiTs are structurally identical and differ only in input packing. Load one,
+selected by conditioning mode — never both.
+
+## Quantization
+
+MLX affine, **8 bits, group size 32**. Per-group scale and bias in BF16, so the effective
+cost is closer to 9 bits per weight than 8.
+
+Not to be confused with ComfyUI's `int8_convrot`, which is tensor-wise int8 plus a
+256-group rotation. That format is unusable from MLX — the rotation has to be folded into
+the compute path, and taking the weights without it destroys accuracy.
+
+Layers under 2 dimensions, and any whose last axis is not divisible by 32, stay dense.
+
+## This is H3-Base only
+
+H3 ships as three stages and only the middle one is open:
+
+| Stage | Role | Here |
+| --- | --- | --- |
+| H3-Context-IR | prompt → structured brief | No, API only |
+| **H3-Base** | 768p joint audio-video generation | **Yes** |
+| H3-Regenerate-2K | 768p → 2K upscale | No, API only |
+
+Two consequences worth knowing before you download 97 GiB:
+
+**Nothing rewrites your prompt.** The hosted product expands a one-line request into a
+structured brief before generation. That stage is not released, so the text you pass is the
+text the encoder sees. See [the prompting notes](https://github.com/appautomaton/mlx-h3/blob/main/docs/prompting.md).
+
+**2K figures from hosted guides do not apply.** Upscaling is the third stage. This is 768p,
+capped at 768×1344.
+
+## Not included
+
+The two VAEs are required at runtime and are **not** quantized — they stay dense, so there
+is no MLX-specific build to publish. Get them from
+[Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3), along with the
+tokenizer.
+
+## Getting started
+
+```sh
+uv tool install --prerelease allow mlx-h3==0.0.1a3
+hf download appautomaton/minimax-h3-base-8bit-mlx --local-dir weights/mlx-8bit
+```
+
+Point the runtime at the files with `--dit`, `--ref-dit`, and `--text-encoder`, or lay them
+out as `mlx-h3` expects and rely on the defaults. Pull one component with `--include` if you
+do not want all three.
+
+## Requirements
+
+Apple silicon with enough unified memory to hold one model at a time. The DiT and text
+encoder are **never co-resident** — `mlx-h3` loads one, materializes its output, releases
+it, and asserts the memory came back. Unstaged they would be 62.5 GiB of weights before a
+single activation. The runtime targets a 70 GiB active budget and treats swap as a failure.
+
+## Links
+
+- Source code: [`appautomaton/mlx-h3`](https://github.com/appautomaton/mlx-h3)
+- Project page: [appautomaton.renocrypt.com/mlx-h3](https://appautomaton.renocrypt.com/mlx-h3/)
+- Upstream model: [MiniMaxAI/MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3)
+
+## License
+
+These are quantized derivatives of MiniMax-H3 — the weights have been modified from the
+original release.
+
+MiniMax-H3 is licensed under the
+[MiniMax H3 Community License Agreement](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE),
+which carries use restrictions and a territorial scope. Read it before using these files.
+
+> MiniMax H3 is licensed under the MiniMax H3 Community License Agreement,
+> Copyright © 2026 MiniMax. All Rights Reserved.
+
+`text-encoder/` derives from Qwen3-VL-32B, licensed under
+[Apache 2.0](https://github.com/QwenLM/Qwen3-VL/blob/main/LICENSE).
+
+The `mlx-h3` runtime code is separately licensed under MIT.

--- a/scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md
+++ b/scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md
@@ -1,4 +1,6 @@
 ---
+language:
+- en
 license: other
 license_name: minimax-h3-community-license
 license_link: https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE
@@ -9,109 +11,98 @@ tags:
 - mlx
 - apple-silicon
 - minimax
+- minimax-h3
 - text-to-video
 - text-to-audio-video
 - audio-video-generation
+- synchronized-audio-video
 - quantized
 ---
 
 # MiniMax-H3-Base — MLX (8-bit)
 
-[![GitHub](https://img.shields.io/badge/GitHub-mlx--h3-181717?logo=github&logoColor=white)](https://github.com/appautomaton/mlx-h3)
-[![App Automaton](https://img.shields.io/badge/App%20Automaton-project-1f6feb)](https://appautomaton.renocrypt.com/mlx-h3/)
-[![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97-appautomaton-yellow)](https://huggingface.co/appautomaton)
+[![PyPI](https://img.shields.io/pypi/v/mlx-h3?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/mlx-h3/)
+[![GitHub](https://img.shields.io/badge/GitHub-mlx--h3-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/appautomaton/mlx-h3)
+[![Project page](https://img.shields.io/badge/project-appautomaton.renocrypt.com-F59E0B?style=flat-square)](https://appautomaton.renocrypt.com/mlx-h3/)
+[![App Automaton](https://img.shields.io/badge/App%20Automaton-project-1f6feb?style=flat-square)](https://appautomaton.renocrypt.com)
+[![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97-appautomaton-yellow?style=flat-square)](https://huggingface.co/appautomaton)
 
-MLX affine 8-bit quantization of **H3-Base**, the open stage of
-[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) — text to synchronized video and
-stereo audio, denoised together in one packed sequence. Runs through the
-[`mlx-h3`](https://github.com/appautomaton/mlx-h3) runtime on Apple silicon, with no
-PyTorch at inference time.
+MLX affine 8-bit conversion of **H3-Base**, the open stage of [MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) — text to synchronized video and stereo audio, denoised together in one packed sequence. Runs on Apple silicon through the [`mlx-h3`](https://github.com/appautomaton/mlx-h3) runtime with no PyTorch, CUDA, or cloud API at inference time.
 
 ## Contents
 
-| Path | Size | What it is |
-| --- | --- | --- |
-| `dit-fl2va/dit_fl2va_a8g32.safetensors` | 34.8 GiB | DiT for text-only and 0–2 keyframe conditioning |
-| `dit-ref2va/dit_ref2va_a8g32.safetensors` | 34.8 GiB | DiT for reference conditioning — up to 9 images, 3 videos, 3 audio clips |
-| `text-encoder/te_qwen3vl_a8g32.safetensors` | 27.7 GiB | Qwen3-VL-32B text encoder and vision tower |
+| File | Size | Role |
+| --- | ---: | --- |
+| `dit_fl2va_a8g32.safetensors` | 34.8 GiB | DiT for text and 0–2 keyframes |
+| `dit_ref2va_a8g32.safetensors` | 34.8 GiB | DiT for reference conditioning |
+| `te_qwen3vl_a8g32.safetensors` | 27.7 GiB | Qwen3-VL-32B text encoder |
 
-The two DiTs are structurally identical and differ only in input packing. Load one,
-selected by conditioning mode — never both.
+Pull one with `--include`; you do not need all three.
+
+The two DiTs are structurally identical and differ only in input packing. Load one, selected by conditioning mode — not both.
 
 ## Quantization
 
-MLX affine, **8 bits, group size 32**. Per-group scale and bias in BF16, so the effective
-cost is closer to 9 bits per weight than 8.
+MLX **affine, 8 bits, group size 32** — the `a8g32` in each filename. One scale and one bias per 32 weights, stored as bf16 alongside the packed integers.
 
-Not to be confused with ComfyUI's `int8_convrot`, which is tensor-wise int8 plus a
-256-group rotation. That format is unusable from MLX — the rotation has to be folded into
-the compute path, and taking the weights without it destroys accuracy.
+This is not ComfyUI's `int8_convrot`, which is tensor-wise int8 plus a 256-group rotation and cannot be loaded from MLX. The distinction is format, not precision.
 
-Layers under 2 dimensions, and any whose last axis is not divisible by 32, stay dense.
+Layers stay dense where quantizing them costs accuracy for no useful saving: anything under two dimensions, and anything whose last axis is not divisible by the group size. 8-bit is the serving configuration here rather than a compromise — the workload is compute-bound, so lower precision buys memory without buying speed.
 
 ## This is H3-Base only
 
-H3 ships as three stages and only the middle one is open:
+MiniMax-H3 ships as three stages. Only the middle one is released.
 
 | Stage | Role | Here |
 | --- | --- | --- |
-| H3-Context-IR | prompt → structured brief | No, API only |
+| H3-Context-IR | prompt → structured brief | No |
 | **H3-Base** | 768p joint audio-video generation | **Yes** |
-| H3-Regenerate-2K | 768p → 2K upscale | No, API only |
+| H3-Regenerate-2K | 768p → 2K upscale | No |
 
 Two consequences worth knowing before you download 97 GiB:
 
-**Nothing rewrites your prompt.** The hosted product expands a one-line request into a
-structured brief before generation. That stage is not released, so the text you pass is the
-text the encoder sees. See [the prompting notes](https://github.com/appautomaton/mlx-h3/blob/main/docs/prompting.md).
-
-**2K figures from hosted guides do not apply.** Upscaling is the third stage. This is 768p,
-capped at 768×1344.
+- **Nothing rewrites your prompt.** The hosted product expands a one-line request into a structured brief first. Here the encoder sees exactly what you send. See [the prompting guide](https://github.com/appautomaton/mlx-h3/blob/main/docs/prompting.md).
+- **Output is 768p.** The 2K figures in hosted guides describe the third stage, which is not open.
 
 ## Not included
 
-The two VAEs are required at runtime and are **not** quantized — they stay dense, so there
-is no MLX-specific build to publish. Get them from
-[Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3), along with the
-tokenizer.
+The VAEs and tokenizer are required at runtime and are **not** in this repository. They are unmodified and available upstream from [Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3):
 
-## Getting started
+```
+video VAE   fp16   4.8 GiB
+audio VAE   fp32   577 MiB
+tokenizer          6.7 MiB
+```
+
+## How to get started
 
 ```sh
-uv tool install --prerelease allow mlx-h3==0.0.1a3
 hf download appautomaton/minimax-h3-base-8bit-mlx --local-dir weights/mlx-8bit
 ```
 
-Point the runtime at the files with `--dit`, `--ref-dit`, and `--text-encoder`, or lay them
-out as `mlx-h3` expects and rely on the defaults. Pull one component with `--include` if you
-do not want all three.
+Runtime install and usage: [`mlx-h3` on PyPI](https://pypi.org/project/mlx-h3/) ·
+[project page](https://appautomaton.renocrypt.com/mlx-h3/) ·
+[GitHub](https://github.com/appautomaton/mlx-h3)
 
 ## Requirements
 
-Apple silicon with enough unified memory to hold one model at a time. The DiT and text
-encoder are **never co-resident** — `mlx-h3` loads one, materializes its output, releases
-it, and asserts the memory came back. Unstaged they would be 62.5 GiB of weights before a
-single activation. The runtime targets a 70 GiB active budget and treats swap as a failure.
+Apple silicon with enough unified memory to hold one model at a time. The DiT and text encoder are **never co-resident** — the runtime loads one, materializes its output, releases it, and asserts the memory came back. Unstaged they would be 62.5 GiB of weights before a single activation. Default active-memory budget is 70 GiB; swap activity is treated as a failure, not a slowdown.
 
 ## Links
 
 - Source code: [`appautomaton/mlx-h3`](https://github.com/appautomaton/mlx-h3)
+- Package: [`mlx-h3` on PyPI](https://pypi.org/project/mlx-h3/)
 - Project page: [appautomaton.renocrypt.com/mlx-h3](https://appautomaton.renocrypt.com/mlx-h3/)
-- Upstream model: [MiniMaxAI/MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3)
+- More from App Automaton: [Project](https://appautomaton.renocrypt.com) · [GitHub](https://github.com/appautomaton) · [Hugging Face](https://huggingface.co/appautomaton)
 
 ## License
 
-These are quantized derivatives of MiniMax-H3 — the weights have been modified from the
-original release.
+These files are **modified** — quantized derivatives of the original release, not the original weights.
 
-MiniMax-H3 is licensed under the
-[MiniMax H3 Community License Agreement](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE),
-which carries use restrictions and a territorial scope. Read it before using these files.
+The two DiTs are governed by the [MiniMax H3 Community License Agreement](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE), which applies to you as a recipient. It carries territorial limits and an acceptable-use policy; read it before use.
 
-> MiniMax H3 is licensed under the MiniMax H3 Community License Agreement,
-> Copyright © 2026 MiniMax. All Rights Reserved.
+> MiniMax H3 is licensed under the MiniMax H3 Community License Agreement, Copyright © 2026 MiniMax. All Rights Reserved.
 
-`text-encoder/` derives from Qwen3-VL-32B, licensed under
-[Apache 2.0](https://github.com/QwenLM/Qwen3-VL/blob/main/LICENSE).
+`text-encoder/` derives from [Qwen3-VL-32B](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct), licensed under [Apache 2.0](https://github.com/QwenLM/Qwen3-VL/blob/main/LICENSE).
 
 The `mlx-h3` runtime code is separately licensed under MIT.

--- a/scripts/hugging_face/upload.py
+++ b/scripts/hugging_face/upload.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Publish the MLX 8-bit MiniMax-H3 artifacts to Hugging Face.
+
+Usage:
+    python scripts/hugging_face/upload.py --dry-run     # plan only, no transfer
+    python scripts/hugging_face/upload.py --card-only   # refresh README.md
+    python scripts/hugging_face/upload.py               # weights, then the card
+
+The local tree is flat and the repository is foldered, so the artifacts are
+hardlinked into a staging directory first. Hardlinks share inodes, so this costs
+no disk even at 97 GiB, and `upload-large-folder` sees an ordinary tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ID = "appautomaton/minimax-h3-base-8bit-mlx"
+
+# local file under weights/mlx-8bit/ -> directory it occupies in the repository
+ARTIFACTS = {
+    "dit_fl2va_a8g32.safetensors": "dit-fl2va",
+    "dit_ref2va_a8g32.safetensors": "dit-ref2va",
+    "te_qwen3vl_a8g32.safetensors": "text-encoder",
+}
+
+SOURCE = Path("weights/mlx-8bit")
+STAGING = Path("weights/.hf-staging")
+CARD = Path("scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md")
+
+
+def resolve_hf() -> str:
+    hf = shutil.which("hf")
+    if hf is None:
+        raise FileNotFoundError(
+            "no hf CLI on PATH; install huggingface_hub or activate the environment"
+        )
+    return hf
+
+
+def stage(root: Path) -> Path:
+    """Hardlink the artifacts into the layout the repository uses."""
+    staging = root / STAGING
+    if staging.exists():
+        shutil.rmtree(staging)
+
+    for name, folder in ARTIFACTS.items():
+        source = root / SOURCE / name
+        if not source.is_file():
+            raise FileNotFoundError(f"missing artifact: {source}")
+        target = staging / folder / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Fall back to a copy across filesystems; hardlinking is the normal path.
+        try:
+            os.link(source, target)
+        except OSError:
+            shutil.copy2(source, target)
+    return staging
+
+
+def run(command: list[str], *, env: dict[str, str]) -> None:
+    print(f"$ {' '.join(command)}")
+    result = subprocess.run(command, check=False, env=env)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--card-only",
+        action="store_true",
+        help="Upload README.md without touching the weights.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan and the commands without transferring anything.",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    card = root / CARD
+    if not card.is_file():
+        raise FileNotFoundError(f"missing model card: {card}")
+
+    env = os.environ.copy()
+    # Xet is disabled for every appautomaton upload; it has not been reliable on
+    # artifacts this size.
+    env["HF_HUB_DISABLE_XET"] = "1"
+
+    if args.dry_run:
+        print(f"repo: {REPO_ID}")
+        total = 0
+        for name, folder in ARTIFACTS.items():
+            source = root / SOURCE / name
+            size = source.stat().st_size if source.is_file() else 0
+            total += size
+            state = "ok" if size else "MISSING"
+            print(f"  {folder}/{name}  {size / 1024**3:.1f} GiB  {state}")
+        print(f"  README.md <- {CARD}")
+        print(f"  total: {total / 1024**3:.1f} GiB")
+        return 0
+
+    hf = resolve_hf()
+
+    if not args.card_only:
+        staging = stage(root)
+        # One worker: these are 35 GiB single files, and parallel streams have
+        # been the thing that breaks rather than the thing that helps.
+        run(
+            [
+                hf,
+                "upload-large-folder",
+                "--repo-type",
+                "model",
+                "--num-workers",
+                "1",
+                REPO_ID,
+                str(staging),
+            ],
+            env=env,
+        )
+
+    run(
+        [hf, "upload", "--repo-type", "model", REPO_ID, str(card), "README.md"],
+        env=env,
+    )
+
+    print(f"Done. https://huggingface.co/{REPO_ID}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hugging_face/upload.py
+++ b/scripts/hugging_face/upload.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 """Publish the MLX 8-bit MiniMax-H3 artifacts to Hugging Face.
 
-Usage:
-    python scripts/hugging_face/upload.py --dry-run     # plan only, no transfer
-    python scripts/hugging_face/upload.py --card-only   # refresh README.md
-    python scripts/hugging_face/upload.py               # weights, then the card
-
-The local tree is flat and the repository is foldered, so the artifacts are
-hardlinked into a staging directory first. Hardlinks share inodes, so this costs
-no disk even at 97 GiB, and `upload-large-folder` sees an ordinary tree.
+python scripts/hugging_face/upload.py --dry-run     plan only
+python scripts/hugging_face/upload.py --card-only   refresh README.md
+python scripts/hugging_face/upload.py               weights, then the card
 """
 
 from __future__ import annotations
@@ -22,98 +17,57 @@ from pathlib import Path
 
 
 REPO_ID = "appautomaton/minimax-h3-base-8bit-mlx"
-
-# local file under weights/mlx-8bit/ -> directory it occupies in the repository
-ARTIFACTS = {
-    "dit_fl2va_a8g32.safetensors": "dit-fl2va",
-    "dit_ref2va_a8g32.safetensors": "dit-ref2va",
-    "te_qwen3vl_a8g32.safetensors": "text-encoder",
-}
-
 SOURCE = Path("weights/mlx-8bit")
-STAGING = Path("weights/.hf-staging")
 CARD = Path("scripts/hugging_face/model_cards/appautomaton/minimax-h3-base-8bit-mlx.md")
+ARTIFACTS = (
+    "dit_fl2va_a8g32.safetensors",
+    "dit_ref2va_a8g32.safetensors",
+    "te_qwen3vl_a8g32.safetensors",
+)
 
 
-def resolve_hf() -> str:
-    hf = shutil.which("hf")
-    if hf is None:
-        raise FileNotFoundError(
-            "no hf CLI on PATH; install huggingface_hub or activate the environment"
-        )
-    return hf
-
-
-def stage(root: Path) -> Path:
-    """Hardlink the artifacts into the layout the repository uses."""
-    staging = root / STAGING
-    if staging.exists():
-        shutil.rmtree(staging)
-
-    for name, folder in ARTIFACTS.items():
-        source = root / SOURCE / name
-        if not source.is_file():
-            raise FileNotFoundError(f"missing artifact: {source}")
-        target = staging / folder / name
-        target.parent.mkdir(parents=True, exist_ok=True)
-        # Fall back to a copy across filesystems; hardlinking is the normal path.
-        try:
-            os.link(source, target)
-        except OSError:
-            shutil.copy2(source, target)
-    return staging
-
-
-def run(command: list[str], *, env: dict[str, str]) -> None:
-    print(f"$ {' '.join(command)}")
-    result = subprocess.run(command, check=False, env=env)
-    if result.returncode != 0:
-        sys.exit(result.returncode)
+def run(command: list[str], env: dict[str, str]) -> None:
+    print(f"$ {' '.join(command)}", flush=True)
+    if subprocess.run(command, check=False, env=env).returncode != 0:
+        sys.exit(1)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--card-only",
-        action="store_true",
-        help="Upload README.md without touching the weights.",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print the plan and the commands without transferring anything.",
-    )
+    parser.add_argument("--card-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[2]
     card = root / CARD
+    source = root / SOURCE
     if not card.is_file():
         raise FileNotFoundError(f"missing model card: {card}")
 
-    env = os.environ.copy()
-    # Xet is disabled for every appautomaton upload; it has not been reliable on
-    # artifacts this size.
-    env["HF_HUB_DISABLE_XET"] = "1"
+    missing = [name for name in ARTIFACTS if not (source / name).is_file()]
+    if missing and not args.card_only:
+        raise FileNotFoundError(f"missing under {source}: {', '.join(missing)}")
 
     if args.dry_run:
+        total = sum((source / name).stat().st_size for name in ARTIFACTS)
         print(f"repo: {REPO_ID}")
-        total = 0
-        for name, folder in ARTIFACTS.items():
-            source = root / SOURCE / name
-            size = source.stat().st_size if source.is_file() else 0
-            total += size
-            state = "ok" if size else "MISSING"
-            print(f"  {folder}/{name}  {size / 1024**3:.1f} GiB  {state}")
+        for name in ARTIFACTS:
+            print(f"  {name}  {(source / name).stat().st_size / 1024**3:.1f} GiB")
         print(f"  README.md <- {CARD}")
         print(f"  total: {total / 1024**3:.1f} GiB")
         return 0
 
-    hf = resolve_hf()
+    hf = shutil.which("hf")
+    if hf is None:
+        raise FileNotFoundError("no hf CLI on PATH; install huggingface_hub")
+
+    env = os.environ.copy()
+    # Xet stalls on artifacts this size. Every appautomaton upload disables it.
+    env["HF_HUB_DISABLE_XET"] = "1"
 
     if not args.card_only:
-        staging = stage(root)
-        # One worker: these are 35 GiB single files, and parallel streams have
-        # been the thing that breaks rather than the thing that helps.
+        # One worker: a single stream already saturates the uplink, so more of
+        # them buy nothing and only widen the window for a stall.
         run(
             [
                 hf,
@@ -122,17 +76,15 @@ def main() -> int:
                 "model",
                 "--num-workers",
                 "1",
+                "--include",
+                "*.safetensors",
                 REPO_ID,
-                str(staging),
+                str(source),
             ],
-            env=env,
+            env,
         )
 
-    run(
-        [hf, "upload", "--repo-type", "model", REPO_ID, str(card), "README.md"],
-        env=env,
-    )
-
+    run([hf, "upload", "--repo-type", "model", REPO_ID, str(card), "README.md"], env)
     print(f"Done. https://huggingface.co/{REPO_ID}")
     return 0
 


### PR DESCRIPTION
Adds `scripts/hugging_face/` — a model card and an upload script for `appautomaton/minimax-h3-base-8bit-mlx`. Nothing is published by this PR; the repository does not exist on the Hub yet and the script creates it.

**Flat layout**, mirroring `weights/mlx-8bit/` one for one:

```
dit_fl2va_a8g32.safetensors      34.8 GiB
dit_ref2va_a8g32.safetensors     34.8 GiB
te_qwen3vl_a8g32.safetensors     27.7 GiB
```

`upload-large-folder` takes no remote-path argument, so a foldered repository would need a staging tree. Flat needs none, and `--include` still allows single-file pulls. Unsharded, because `loading.py` calls `mx.load` on a single path at six sites.

**Named `8bit`, not `int8`.** `int8` is already spent in `docs/weights.md` on ComfyUI's `int8_convrot`, and conventionally implies symmetric per-tensor quantization; this is affine with a per-group bias. `affine` is absent from the name because it is `mx.quantize`'s default and appears nowhere in mlx-community's naming. `-base-` because only the middle stage of H3 is open.

**Transfer flags.** `HF_HUB_DISABLE_XET=1` — `hf_xet` 1.4.2 is installed and active by default on this machine, and it stalls on artifacts this size. `--num-workers 1` costs nothing: measured 13.4 MB/s on a single stream against 12.0 MB/s across three, so the uplink is the bottleneck, not the worker count. Roughly 2.2 hours for 97.2 GiB.

**VAEs excluded** — they stay dense, so there is no MLX build to publish. The card points at `Comfy-Org/MiniMax-H3`.

**Card** carries the required NOTICE string, states the files are modified derivatives, links the MiniMax H3 Community License Agreement rather than reproducing it, and notes the text encoder derives from Qwen3-VL-32B under Apache 2.0. No pinned version anywhere — the PyPI badge resolves it live.

Verified: `--dry-run` resolves all three at 97.2 GiB, ruff clean, public-tree check passes.

**Unrelated one-liner.** `uv.lock` still pinned `0.0.1a2`; running the dry-run refreshed it to `0.0.1a3`. Correct, just off-topic here.